### PR TITLE
Optimizing performance and refactoring recordStore.

### DIFF
--- a/src/components/fund/FundsList.vue
+++ b/src/components/fund/FundsList.vue
@@ -6,7 +6,7 @@
         {{ fund.name }}
       </dt>
       <dd class="flex justify-end my-2 mr-3">
-        {{ balanceFormatted(fund) }}
+        {{ getFundBalance(fund) }}
       </dd>
     </div>
   </dl>
@@ -22,14 +22,23 @@ const props = defineProps({
   balanceOnRecords: {
     type: Boolean,
     default: false,
-  }
+  },
 })
 
 const fundStore = useFundStore();
 const { funds } = storeToRefs(fundStore);
 
 const recordStore = useRecordStore();
-const { records } = storeToRefs(recordStore);
+const { typeSum } = storeToRefs(recordStore);
+
+function getFundBalance({ id, balance }) {
+  if (!props.balanceOnRecords) return getBalanceFormatted(balance);
+  const fundAssignmentSum = typeSum.value[0].byFund[id] || 0;
+  const fundCreditSum = typeSum.value[1].byFund[id] || 0;
+  const fundDebitSum = typeSum.value[2].byFund[id] || 0;
+  const balanceOnRecords = fundCreditSum + fundAssignmentSum + fundDebitSum;
+  return getBalanceFormatted(balanceOnRecords)
+}
 
 function getBalanceFormatted(amount) {
   const integer = Math.floor(amount);
@@ -41,17 +50,6 @@ function getBalanceFormatted(amount) {
     style: "currency",
     currency: "USD",
   }).format(recomposed)
-}
-
-function balanceFormatted(fund) {
-  if (!props.balanceOnRecords) return getBalanceFormatted(fund.balance);
-  const balanceOnRecords = records.value
-    .filter(record => record.fundID === fund.id || record.otherFundID === fund.id)
-    .reduce((balance, { fundID, amount }) => {
-      const recordAmount = fundID === fund.id ? amount : -(amount);
-      return balance + recordAmount;
-    }, 0);
-  return getBalanceFormatted(balanceOnRecords)
 }
 
 </script>

--- a/src/components/projection/Stats.vue
+++ b/src/components/projection/Stats.vue
@@ -14,26 +14,23 @@
 
 <script setup>
 import { computed } from 'vue';
-import { storeToRefs } from 'pinia';
-import { useRecordStore } from '../../stores/recordStore';
 
-const recordStore = useRecordStore();
-const { records } = storeToRefs(recordStore);
-
-const yearRecords = computed(() => {
-  const isFromCurrentYear = (date) => new Date(date).getFullYear() === new Date().getFullYear();
-  const filteredRecords = records.value.filter(({ date, type }) => isFromCurrentYear(date) && type !== 0)
-  return filteredRecords;
+const props = defineProps({
+  sampleRecords: {
+    type: Array,
+    default: [],
+  },
 });
+
 const currentMonth = Number(new Intl.DateTimeFormat('en-US', { month: '2-digit' }).format(new Date()));
 
-const yearCredits = computed(() => yearRecords.value.filter((record) => record.type === 1));
-const yearDebits = computed(() => yearRecords.value.filter((record) => record.type === 2));
+const yearCredits = computed(() => props.sampleRecords.filter((record) => record.type === 1));
+const yearDebits = computed(() => props.sampleRecords.filter((record) => record.type === 2));
 const creditsBalance = computed(() => yearCredits.value.reduce((balance, { amount }) => (balance + Number(amount)), 0));
 const debitsBalance = computed(() => yearDebits.value.reduce((balance, { amount }) => (balance + Number(amount)), 0));
 const yearBalance = computed(() => creditsBalance.value + debitsBalance.value);
-const yearSavings = computed(() => (creditsBalance.value > 0) ? (yearBalance.value / creditsBalance.value) * 100 : 0);
-const averageMonthSaving = computed(() => (yearBalance.value / (currentMonth - 1)).toFixed());
+const yearSavings = computed(() => (yearBalance.value / creditsBalance.value) * 100);
+const averageMonthSaving = computed(() => Number(yearBalance.value / (currentMonth - 1)).toFixed());
 
 const stats = computed(() => [
   { id: 1, name: 'Saved until now', value: yearSavings.value.toFixed() + '%'},

--- a/src/components/query/QueryFundsChart.vue
+++ b/src/components/query/QueryFundsChart.vue
@@ -12,42 +12,38 @@ const props = defineProps({
   records: {
     type: Array,
     required:  true,
+  },
+  typeSum: {
+    type: Object,
+    required: true,
   }
 })
 
 const fundStore = useFundStore();
 const { funds } = storeToRefs(fundStore);
 
-const fundsNames = computed(() => funds.value.map(fund => fund.name));
-const fundsBalances = computed(() => {
-  const totalCreditsByFund = Object.fromEntries(funds.value.map(fund => [fund.id, 0 ]));
-  const totalDebitsByFund = Object.fromEntries(funds.value.map(fund => [fund.id, 0 ]));
-
-  for (const record of props.records) {
-    if (record.type === 1) totalCreditsByFund[record.fundID] += record.amount;
-    else if (record.type === 2) totalDebitsByFund[record.fundID] -= record.amount;
-    if (record.type === 0) {
-      totalCreditsByFund[record.otherFundID] -= record.amount;
-      totalDebitsByFund[record.fundID] -= record.amount;
-    }
-  }
-  return { totalCreditsByFund, totalDebitsByFund }
-})
+const fundNames = funds.value.map(fund => fund.name);
 
 const chartData = computed(() => {
+
   return {
-    labels: fundsNames.value,
+    labels: fundNames,
     datasets: [
-      {
+    {
         label: "Credit",
-        data: Object.values(fundsBalances.value.totalCreditsByFund),
+        data: Object.values(props.typeSum[1].byFund),
         backgroundColor: '#69a060',
       },
       {
         label: "Debit",
-        data: Object.values(fundsBalances.value.totalDebitsByFund),
+        data: Object.values(props.typeSum[2].byFund),
         backgroundColor: '#da6960',
-      }
+      },
+      {
+        label: "Assignment",
+        data: Object.values(props.typeSum[0].byFund),
+        backgroundColor: '#60b0b0',
+      },
     ],
   }
 });

--- a/src/components/query/QueryTagsChart.vue
+++ b/src/components/query/QueryTagsChart.vue
@@ -7,10 +7,14 @@ import { computed } from 'vue';
 import { Doughnut } from 'vue-chartjs'
 
 const props = defineProps({
-  tagsData: {
-    type: Array,
-    default: [],
+  taglistRef: {
+    type: Object,
+    default: {},
   },
+  tagNames: {
+    type: Object,
+    default: {},
+  }
 })
 
 const colors = [
@@ -39,14 +43,15 @@ const colors = [
   "#2dd4bf",
 ];
 
-const tagsNames = computed(() => props.tagsData.map(tag => tag.name));
-const tagsBalance = computed(() => props.tagsData.map(tag => tag.balance));
-
 const chartData = computed(() => {
   return {
-    labels: tagsNames.value,
+    labels: props.tagNames[props.taglistRef.type],
     datasets: [
-      { label: " %", data: tagsBalance.value, backgroundColor: colors },
+      {
+        label: " $",
+        data: props.taglistRef.tagList.map(tag => tag.tagSum),
+        backgroundColor: colors
+      },
     ],
   }
 });
@@ -54,7 +59,7 @@ const chartOptions = {
   plugins: {
     legend: {
       position: "bottom",
-      labels: { color: "#5d5d5d" }
+      labels: { color: "#777" }
     }
   }
 };

--- a/src/components/query/QueryTagsList.vue
+++ b/src/components/query/QueryTagsList.vue
@@ -4,24 +4,25 @@
       <div class="flex items-center justify-between px-4">
         <div class="flex items-center gap-2">
           <component
-          :class="[iconStyles, ' bg-opacity-20 flex p-0.5 rounded-full h-5 w-5']"
-          :is="icon"></component>
-          <select class="font-bold flex my-4 mx-auto text-lg border-none bg-transparent shadow-md rounded-full focus:ring-violet-500 focus:outline-none" v-model="type">
+          :class="[iconStyles[type], ' bg-opacity-20 flex p-0.5 rounded-full h-5 w-5']"
+          :is="icon[type]"></component>
+          <select class="font-bold flex my-4 mx-auto text-lg border-none bg-transparent shadow-sm rounded-full focus:shadow-violet-200 focus:ring-0 focus:outline-none" v-model="type">
             <option class="bg-stone-700 text-white" :value="2">Debits</option>
             <option class="bg-stone-700 text-white" :value="1">Credits</option>
             <option class="bg-stone-700 text-white" :value="0">Assignments</option>
           </select>
         </div>
-        <span class="text-sm">Total: {{ tagsData.length }}</span>
       </div>
-      <div v-for="tag, i in tagsData" :key="i" class="my-1 rounded-md shadow-md bg-white dark:bg-stone-800 flex justify-between items-center">
+      <div v-for="tag, i in tagList" :key="i" class="my-1 rounded-md shadow-md bg-white dark:bg-stone-800 flex justify-between items-center">
         <dt class="flex items-center gap-4 p-3">
           <TagIcon class="w-8 mx-auto p-1.5 rounded-full shadow-md text-stone-500 dark:text-stone-400 dark:shadow-[#101010] bg-stone-100 dark:bg-stone-800" />
-          <span>{{ tag.name }}</span>
+          <span class="text-sm">{{ tag.tagName }}</span>
         </dt>
-        <dd class="justify-end flex items-baseline my-2 mr-3">
-          <span class="text-stone-500 dark:text-stone-300">{{ getAmountFormatted(tag.balance) }}</span>
-          <strong class="bg-stone-100 dark:bg-stone-900 rounded-sm px-2 w-16 text-center mx-4">{{ tag.percentage }}%</strong>
+        <dd class="justify-end flex items-baseline my-2 mr-3 text-sm">
+          <span class="text-stone-500 dark:text-stone-300">{{ getAmountFormatted(tag.tagSum) }}</span>
+          <strong class="shadow-sm dark:shadow-[#101010] bg-stone-100 dark:bg-stone-800 rounded-sm px-0.5 w-16 text-center mx-4">
+            {{ tagPercentage(tag.tagSum) }} %
+          </strong>
         </dd>
       </div>
     </dl>
@@ -33,53 +34,31 @@ import { TagIcon, PlusIcon, MinusIcon, ArrowsRightLeftIcon } from '@heroicons/vu
 import { computed, ref } from 'vue';
 
 const props = defineProps({
-  records: {
-    type: Array,
+  tagData: {
+    type: Object,
+    required: true,
+  },
+  typeSum: {
+    type: Object,
     required: true,
   }
 });
 
 const type = ref(2);
+const tagList = computed(() => props.tagData[type.value]);
 
-const icon = computed(() => {
-  if (type.value === 2) return MinusIcon
-  else if (type.value === 1) return PlusIcon
-  else return ArrowsRightLeftIcon
-});
+const icon = {
+  2: MinusIcon,
+  1: PlusIcon,
+  0: ArrowsRightLeftIcon,
+};
+const iconStyles = {
+  2: 'text-red-500 bg-red-600',
+  1: 'text-green-500 bg-green-600',
+  0: 'text-stone-500 bg-stone-600',
+};
 
-
-const iconStyles = computed(() => {
-  if (type.value === 2) return 'text-red-500 bg-red-600'
-  else if (type.value === 1) return 'text-green-500 bg-green-600'
-  else return 'text-stone-500 bg-stone-600'
-});
-const typeRecords = computed(() => props.records.filter(record => record.type === type.value));
-
-const typeBalance = computed(() => typeRecords.value
-  .reduce((balance, { amount }) => balance + amount, 0)
-);
-
-const tagsData = computed(() => {
-  const tagsInfo = [];
-
-  for (const tag of uniqueTags.value) {
-    const tagInfo = { name: tag, balance: 0, percentage: 0 };
-    tagInfo.balance = typeRecords.value
-      .filter(record => record.tag === tag)
-      .reduce((balance, { amount }) => balance + amount, 0)
-      .toFixed();
-    tagInfo.percentage = (tagInfo.balance / typeBalance.value * 100).toFixed();
-    tagsInfo.push(tagInfo);
-  }
-  tagsInfo.sort((t1, t2) => type.value === 1 ? (t2.balance - t1.balance) : (t1.balance - t2.balance));
-  return tagsInfo;
-});
-
-const uniqueTags = computed(() => {
-  const recordsTags = typeRecords.value.map(record => record.tag);
-  const uniqueTags = Array.from(new Set([...recordsTags]));
-  return uniqueTags;
-})
+const tagPercentage = (tagSum) => ((tagSum / props.typeSum[type.value].total) * 100).toFixed(1);
 
 function getAmountFormatted(amount) {
   const integer = Math.floor(amount);
@@ -93,5 +72,6 @@ function getAmountFormatted(amount) {
   }).format(recomposed)
 }
 
-defineExpose({ tagsData });
+defineExpose({ type, tagList });
+
 </script>

--- a/src/components/query/QueryYearlyChart.vue
+++ b/src/components/query/QueryYearlyChart.vue
@@ -3,6 +3,7 @@
 </template>
 
 <script setup>
+import { useDateFormat } from '@vueuse/shared';
 import { computed } from 'vue';
 import { Line } from 'vue-chartjs';
 
@@ -13,78 +14,36 @@ const props = defineProps({
   }
 })
 
-const months = [
-  'January',
-  'February',
-  'March',
-  'April',
-  'May',
-  'June',
-  'July',
-  'August',
-  'September',
-  'October',
-  'November',
-  'December',
+const monthsData = [
+  { balance: 0, name: 'January' },
+  { balance: 0, name: 'February' },
+  { balance: 0, name: 'March' },
+  { balance: 0, name: 'April' },
+  { balance: 0, name: 'May' },
+  { balance: 0, name: 'June' },
+  { balance: 0, name: 'July' },
+  { balance: 0, name: 'August' },
+  { balance: 0, name: 'September' },
+  { balance: 0, name: 'October' },
+  { balance: 0, name: 'November' },
+  { balance: 0, name: 'December' },
 ];
 
-const monthsBalance = computed(() => {
-  const result = [];
-  months.forEach(month => {
-    const monthMatch = (date) => new Intl.DateTimeFormat('en-US', { month: 'long' }).format(new Date(date)) === month;
-    const yearMatch = (date) => new Date(date).getFullYear() === new Date().getFullYear();
-    const monthRecords = props.records.filter(({ date, type }) => monthMatch(date) && yearMatch(date) && type !== 0);
-    const monthBalance = monthRecords.reduce((acc, record) => acc + record.amount, 0);
-    result.push(monthBalance);
-  });
-  return result;
-});
-
-const monthsCredits = computed(() => {
-  const result = [];
-  months.forEach(month => {
-    const monthMatch = (date) => new Intl.DateTimeFormat('en-US', { month: 'long' }).format(new Date(date)) === month;
-    const yearMatch = (date) => new Date(date).getFullYear() === new Date().getFullYear();
-    const monthRecords = props.records.filter(({ date, type }) => monthMatch(date) && yearMatch(date) && type === 1);
-    const monthBalance = monthRecords.reduce((acc, record) => acc + record.amount, 0);
-    result.push(monthBalance);
-  });
-  return result;
-});
-
-const monthsDebits = computed(() => {
-  const result = [];
-  months.forEach(month => {
-    const monthMatch = (date) => new Intl.DateTimeFormat('en-US', { month: 'long' }).format(new Date(date)) === month;
-    const yearMatch = (date) => new Date(date).getFullYear() === new Date().getFullYear();
-    const monthRecords = props.records.filter(({ date, type }) => monthMatch(date) && yearMatch(date) && type === 2);
-    const monthBalance = monthRecords.reduce((acc, record) => acc - record.amount, 0);
-    result.push(monthBalance);
-  });
-  return result;
-});
-
 const chartData = computed(() => {
+  monthsData.forEach((month) => month.balance = 0);
+  const sampleRecords = props.records.filter(record => record.type !== 0);
+  sampleRecords.forEach(({ date, amount }) => {
+    const recordMonth = useDateFormat(new Date(date), "MM").value;
+    monthsData[recordMonth - 1].balance += amount;
+  })  
   return {
-    labels: months,
+    labels: monthsData.map(month => month.name),
     datasets: [
-      {
-        label: "Credits",
-        backgroundColor: '#22c55e',
-        borderColor: "#bbf7d0",
-        data: monthsCredits.value,
-      },
-      {
-        label: "Debits",
-        backgroundColor: '#dc2626',
-        borderColor: "#fecaca",
-        data: monthsDebits.value,
-      },
       {
         label: "Balance",
         backgroundColor: '#7c3aed',
         borderColor: "#c4b5fd",
-        data: monthsBalance.value,
+        data: monthsData.map(month => month.balance),
       },
     ],
   }

--- a/src/components/record/RecordForm.vue
+++ b/src/components/record/RecordForm.vue
@@ -274,7 +274,7 @@ const fundStore = useFundStore();
 const { funds } = storeToRefs(fundStore);
 
 const recordStore = useRecordStore();
-const { tags } = storeToRefs(recordStore);
+const { tagNames } = storeToRefs(recordStore);
 
 const userStore = useUserStore();
 const { preferences } = storeToRefs(userStore);
@@ -297,7 +297,7 @@ const focusedTagIndex = ref(0);
 
 const typeTags = computed(() => {
   const formTag = form.tag?.toLowerCase() || "";
-  const matchingTags = tags.value[form.type]
+  const matchingTags = tagNames.value[form.type]
     .filter(tag => tag.toLowerCase().includes(formTag))
     .sort();
   return matchingTags;

--- a/src/stores/recordStore.js
+++ b/src/stores/recordStore.js
@@ -1,29 +1,112 @@
 import { defineStore } from 'pinia';
-import { ref, computed, watch } from 'vue';
-import { useLocalStorage } from '@vueuse/core';
+import { useDateFormat, useLocalStorage } from '@vueuse/core';
 import { useAuthStore } from "./authStore";
 import { useFundStore } from './fundStore';
 import { Find, Create, Update, Delete } from '../services/recordAPI';
 import router from '../router';
 
 export const useRecordStore = defineStore('records', () => {
+
   const records = useLocalStorage('vueUseRecords', []);
   const sampleRecords = useLocalStorage('vueUseSample', []);
   const authStore = useAuthStore();
   const fundStore = useFundStore();
 
-  const tags = computed(() => {
-    const recordWithTags = records.value.filter(r => r.tag);
-    const filteredRecords = { 0: [], 1: [], 2: [] };
-    recordWithTags.forEach(record => {
-      const notIncluded = !filteredRecords[record.type].includes(record.tag);
-      if (notIncluded) filteredRecords[record.type].push(record.tag)
-    })
-    return filteredRecords;
+  const tagData = useLocalStorage("vueUseTagData", {
+    0: [],
+    1: [],
+    2: [],
+  });
+  const typeSum = useLocalStorage("vueUseTypeSumByFund", {
+    0: { total: 0, byFund: {} },
+    1: { total: 0, byFund: {} },
+    2: { total: 0, byFund: {} }
+  });
+  const monthlyBalance = useLocalStorage("vueUseMonthlyBalance", {
+    "01": 0,
+    "02": 0,
+    "03": 0,
+    "04": 0,
+    "05": 0,
+    "06": 0,
+    "07": 0,
+    "08": 0,
+    "09": 0,
+    "10": 0,
+    "11": 0,
+    "12": 0
+  });
+  const tagNames = useLocalStorage("vueUseTagNames", {
+    0: [],
+    1: [],
+    2: []
   });
 
+  function updateStore(recordData) {
+    const tagIndexer = { 0: {}, 1: {}, 2: {} };
+    const tagCounter = { 0: 0, 1: 0, 2: 0 };
+
+    recordData.forEach(({ fundID, type, date, tag, amount, otherFundID }) => {
+      const tagName = tag ?? "Not tagged";
+      const tagNotIndexed = tagIndexer[type][tagName] === undefined;
+      const index = tagNotIndexed ? tagCounter[type] : tagIndexer[type][tagName];
+
+      if (tagNotIndexed) {
+        tagIndexer[type][tagName] = tagCounter[type];
+        tagCounter[type]++;
+        insertTag(type, tagName);
+      }
+
+      updateSumByType({ type, fundID, amount, otherFundID });
+      updateTagMonthly(date, type, index, amount);
+      tagData.value[type][index].tagSum += amount;
+    });
+  }
+
+  function resetState() {
+    tagData.value = {
+      0: [],
+      1: [],
+      2: []
+    };
+    tagNames.value = {
+      0: [],
+      1: [],
+      2: []
+    };
+    typeSum.value = {
+      0: { total: 0, byFund: {} },
+      1: { total: 0, byFund: {} },
+      2: { total: 0, byFund: {} }
+    };
+    monthlyBalance.value = { "01": 0, "02": 0, "03": 0, "04": 0, "05": 0, "06": 0, "07": 0, "08": 0, "09": 0, "10": 0, "11": 0, "12": 0 };
+  }
+
+  function insertTag(type, tagName) {
+    const tagMonthlySum = { "01": 0, "02": 0, "03": 0, "04": 0, "05": 0, "06": 0, "07": 0, "08": 0, "09": 0, "10": 0, "11": 0, "12": 0 };
+    tagNames.value[type].push(tagName);
+    tagData.value[type].push({ tagName, tagSum: 0, tagMonthlySum });
+  }
+
+  function updateSumByType({ type, fundID, amount, otherFundID }) {
+    if (typeSum.value[type].byFund[fundID]) typeSum.value[type].byFund[fundID] += amount;
+    else typeSum.value[type].byFund[fundID] = amount;
+    if (type === 0 && typeSum.value[type].byFund[otherFundID]) typeSum.value[type].byFund[otherFundID] -= amount;
+    else if (type === 0) typeSum.value[type].byFund[otherFundID] = -amount;
+    if (type === 0) typeSum.value[type].total -= amount;
+    else typeSum.value[type].total += amount;
+  }
+
+  function updateTagMonthly(date, type, index, amount) {
+    const month = useDateFormat(new Date(date), "MM").value;
+    tagData.value[type][index].tagMonthlySum[month] += amount;
+    if (type !== 0) monthlyBalance.value[month] += amount;
+  }
+  
   const mutations = {
     setRecords: ({ data, message }) => {
+      resetState();
+      updateStore(data);  
       if (data.length > 0) records.value = [...data];
       return message;
     },
@@ -34,18 +117,24 @@ export const useRecordStore = defineStore('records', () => {
     createRecord: ({ data, message }) => {
       records.value.push(data.record)
       data.funds.forEach((fund) => fundStore.mutations.updateFund({ data: fund }));
+      resetState();
+      updateStore(records.value);  
       return message;
     },
     updateRecord: ({ data, message }) => {
       const index = records.value.findIndex(r => r.id === data.record.id)
       records.value.splice(index, 1, data.record);
       data.funds.forEach((fund) => fundStore.mutations.updateFund({ data: fund }));
+      resetState();
+      updateStore(records.value);  
       return message;
     },
     deleteRecord: ({ data, message }) => {
       const index = records.value.findIndex(r => r.id === data.record.id)
       records.value.splice(index, 1);
       data.funds.forEach((fund) => fundStore.mutations.updateFund({ data: fund }));
+      resetState();
+      updateStore(records.value);  
       return message;
     }
   };
@@ -92,18 +181,17 @@ export const useRecordStore = defineStore('records', () => {
     mutation: mutations.deleteRecord
   });
 
-  watch(records, () => {
-    records.value.sort((a, b) => new Date(b.date) - new Date(a.date))
-  }, { immediate: true })
-
   return {
     records,
     sampleRecords,
-    tags,
     getRecords,
     setRecords: mutations.setRecords,
     createRecord,
     updateRecord,
     deleteRecord,
+    tagData,
+    tagNames,
+    typeSum,
+    monthlyBalance,
   };
 })

--- a/src/views/Projection.vue
+++ b/src/views/Projection.vue
@@ -50,12 +50,19 @@
     <div class="xl:w-10/12 mx-auto dark:bg-stone-800 p-2">
       <LineChart :chart-data="chartData" />
     </div>
+    <div class="my-20">
+      <LightBulbIcon class="my-4 w-12 mx-auto p-2.5 rounded-full shadow-lg text-stone-500 dark:text-stone-400 dark:shadow-[#101010] bg-stone-100 dark:bg-stone-800" />
+      <h2 class="mb-2 text-3xl font-bold text-center">A close look</h2>
+      <p class="mb-10 text-center">Some valuable data about your management</p>
+      <h2 class="mb-2 text-2xl font-bold text-center">This year on average</h2>
+      <Stats :sample-records="sampleRecords" />
+    </div>
   </div>
 </template>
 
 <script setup>
 import { ref, inject, onMounted, watch } from "vue";
-import { CurrencyDollarIcon } from '@heroicons/vue/24/outline';
+import { CurrencyDollarIcon, LightBulbIcon } from '@heroicons/vue/24/outline';
 import { storeToRefs } from "pinia";
 import { useDateFormat } from "@vueuse/shared";
 import { useNow } from "@vueuse/core";
@@ -64,6 +71,7 @@ import { useFundStore } from "../stores/fundStore";
 import LineChart from "../components/projection/LineChart.vue";
 import Dialog from '../components/layout/Dialog.vue';
 import router from "../router";
+import Stats from '../components/projection/Stats.vue';
 
 onMounted(() => runProjection());
 

--- a/src/views/Records.vue
+++ b/src/views/Records.vue
@@ -22,10 +22,10 @@
         <p class="text-center">Check the tags among the results</p>
         <div class="md:flex my-10 justify-center space-x-1">
           <div class="md:w-1/2 xl:w-1/3 p-4 shadow-md rounded-md bg-white dark:bg-stone-800">
-            <QueryTagsList ref="tagsList" :records="records" />
+            <QueryTagsList ref="taglistRef" :tag-data="tagData" :type-sum="typeSum" />
           </div>
           <div class="md:w-1/2 xl:w-1/3 p-4 shadow-md rounded-md bg-white dark:bg-stone-800">
-            <QueryTagsChart :records="records" :tags-data="tagsList.tagsData" />
+            <QueryTagsChart :taglist-ref="taglistRef" :tag-names="tagNames" />
           </div>
         </div>
       </div>
@@ -35,7 +35,7 @@
           <ArchiveBoxIcon class="my-4 w-12 mx-auto p-2.5 rounded-full shadow-lg text-stone-500 dark:text-stone-400 dark:shadow-[#101010] bg-stone-100 dark:bg-stone-800" />
           <h2 class="mb-2 text-3xl font-bold text-center">Funds management</h2>
           <p class="text-center">Credits, debits, and balance by fund</p>
-          <FundsChart class="p-2 shadow-md" :records="records" />
+          <FundsChart class="p-2 shadow-md" :records="records" :type-sum="typeSum" />
           <FundsList :balance-on-records="true" />
         </div>
         <div class="hidden xl:inline w-full md:w-1/2 xl:w-2/3 p-10 shadow-md rounded-md bg-white dark:bg-stone-800">
@@ -45,17 +45,10 @@
           <QueryYearlyChart class="p-2 shadow-md" :records="records" />
         </div>
       </div>
-      <div class="my-20">
-        <LightBulbIcon class="my-4 w-12 mx-auto p-2.5 rounded-full shadow-lg text-stone-500 dark:text-stone-400 dark:shadow-[#101010] bg-stone-100 dark:bg-stone-800" />
-        <h2 class="mb-2 text-3xl font-bold text-center">A close look</h2>
-        <p class="mb-10 text-center">Some valuable data about your management</p>
-        <h2 class="mb-2 text-2xl font-bold text-center">This year on average</h2>
-        <Stats />
-      </div>
-
-      <div class="mt-20 space-x-2 justify-center flex">
-        <h3 class="font-bold text-2xl"><span class="text-violet-500">Planning</span> Time?</h3>
-        <router-link to="/projection" class="text-violet-500 py-1 gap-2 rounded-md flex justify-center" @click.native="scrollToTop">
+      <div class="mt-20 space-x-2 justify-center flex items-center">
+        <ArrowTrendingUpIcon class="w-6" />
+        <h3 class="font-bold text-2xl">Planning Time?</h3>
+        <router-link to="/projection" class="bg-violet-500 text-white py-0.5 px-1.5 font-bold gap-2 rounded-sm flex justify-center" @click.native="scrollToTop">
           <LinkIcon class="w-4" />
           Check projection
         </router-link>
@@ -70,18 +63,17 @@
 <script setup>
 import { defineAsyncComponent, ref } from 'vue'
 import { storeToRefs } from "pinia";
-import { ArchiveBoxIcon, TagIcon, CalendarIcon, LightBulbIcon, LinkIcon, ArrowDownIcon } from '@heroicons/vue/24/outline';
+import { ArchiveBoxIcon, TagIcon, CalendarIcon, LinkIcon, ArrowDownIcon, ArrowTrendingUpIcon } from '@heroicons/vue/24/outline';
 import { Chart as ChartJS, BarElement, CategoryScale, LinearScale, Tooltip, Legend, ArcElement, LineElement, PointElement } from 'chart.js';
 
+import { useDateFormat } from '@vueuse/shared';
+import { useFundStore } from '../stores/fundStore';
 import { useRecordStore } from '../stores/recordStore';
 import QueryPanel from '../components/query/QueryPanel.vue';
-import { useFundStore } from '../stores/fundStore';
-import { useDateFormat } from '@vueuse/shared';
 
 ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip, Legend, ArcElement, LineElement, PointElement);
 ChartJS.defaults = { responsive: true };
 
-const Stats = defineAsyncComponent(() => import('../components/query/QueryStats.vue'));
 const QueryTagsList = defineAsyncComponent(() => import('../components/query/QueryTagsList.vue'));
 const FundsList = defineAsyncComponent(() => import('../components/fund/FundsList.vue'));
 const QueryTotals = defineAsyncComponent(() => import('../components/query/QueryTotals.vue'));
@@ -91,17 +83,20 @@ const QueryYearlyChart = defineAsyncComponent(() => import('../components/query/
 const QueryTagsChart = defineAsyncComponent(() => import('../components/query/QueryTagsChart.vue'));
 
 const fundStore = useFundStore();
-const { funds } = storeToRefs(fundStore);
 const recordStore = useRecordStore();
+const { funds } = storeToRefs(fundStore);
 const { records } = storeToRefs(recordStore);
-const tagsList = ref(null);
-tagsList.value = ref(tagsList.tagsData)
+const { tagData } = storeToRefs(recordStore);
+const { typeSum } = storeToRefs(recordStore);
+const { tagNames } = storeToRefs(recordStore);
+
+const taglistRef = ref(null);
 
 let recordsXls = [];
 const typeNames = {
   0: "Assignment",
   1: "Credit",
-  2: "Debit",
+  2: "Debit"
 };
 
 function getFundName (id) {


### PR DESCRIPTION
Several changes applied to record store having as goal reducing the computed data to elevate performance / UX.
- On records events, there's only one iteration on records to set all the data for the store, and this allocates now most of the data required by the query view and child components (list, tables, charts, etc.).
- Stats component moved to Projection view, where it seems to fit better since the relation of the data (yearly).